### PR TITLE
Remove secrects.ini from docker they are not need

### DIFF
--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -21,8 +21,6 @@ WORKDIR /data
 # other copy
 COPY *.json /
 COPY *.py /
-COPY secrets.ini /data
-COPY secrets.ini /
 #COPY *.html /
 
 COPY templates /

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -21,8 +21,6 @@ WORKDIR /data
 # other copy
 COPY *.json /
 COPY *.py /
-COPY secrets.ini /data
-COPY secrets.ini /
 #COPY *.html /
 
 COPY templates /


### PR DESCRIPTION
Removed copy not existing file in docker - this cause a docker fail. This is quick fix.