### PR TITLE
Rename capacitor to array_size

### DIFF
--- a/edge/hoymilesapi.py
+++ b/edge/hoymilesapi.py
@@ -238,21 +238,22 @@ class Hoymiles(object):
         return self.solar_data
 
     def adjust_solar_data(self, solar_data: dict) -> dict:
-        """Adjust solar data like unifed measurements units
+        """Adjust solar data like unifed measurements units.
 
-        Rename keys: capacitor to array_size and capacitor_kW to array_size_kW
+        Rename key: capacitor to array_size.  solar_data['capacitor':''] from
+        Hoymiles holds PV array size in watts.
 
         Args:
-            solar_data (dict): data retrun from API
+            solar_data (dict): data returned from API
 
         Returns:
             dict: adjusted solar data
         """
         real_power = float(solar_data['real_power'])
-        capacidade = float(solar_data['capacitor'])
-        if 0 < capacidade < 100:
-            capacidade = capacidade * 1000
-        power_ratio = (real_power / capacidade) * 100
+        array_size = float(solar_data['capacitor'])
+        if 0 < array_size < 100:
+            array_size = array_size * 1000
+        power_ratio = (real_power / array_size) * 100
         power_ratio = round(power_ratio, 1)
         if real_power == 0:
             self.logger.warning("real_power = 0")
@@ -262,8 +263,8 @@ class Hoymiles(object):
         solar_data['real_power_measurement'] = str(real_power)
         solar_data['real_power_total_increasing'] = str(real_power)
         solar_data['power_ratio'] = str(power_ratio)
-        solar_data['array_size'] = str(capacidade)
-        solar_data['array_size_kW'] = str(capacidade / 1000)
+        solar_data['array_size'] = str(array_size)
+        solar_data['array_size_kW'] = str(array_size / 1000)
         del solar_data['capacitor']
         co2 = round(float(solar_data['co2_emission_reduction']) / 1000000, 5)
         solar_data['co2_emission_reduction'] = str(co2)

--- a/edge/hoymilesapi.py
+++ b/edge/hoymilesapi.py
@@ -240,6 +240,8 @@ class Hoymiles(object):
     def adjust_solar_data(self, solar_data: dict) -> dict:
         """Adjust solar data like unifed measurements units
 
+        Rename keys: capacitor to array_size and capacitor_kW to array_size_kW
+
         Args:
             solar_data (dict): data retrun from API
 
@@ -260,8 +262,9 @@ class Hoymiles(object):
         solar_data['real_power_measurement'] = str(real_power)
         solar_data['real_power_total_increasing'] = str(real_power)
         solar_data['power_ratio'] = str(power_ratio)
-        solar_data['capacitor'] = str(capacidade)
-        solar_data['capacitor_kW'] = str(capacidade / 1000)
+        solar_data['array_size'] = str(capacidade)
+        solar_data['array_size_kW'] = str(capacidade / 1000)
+        del solar_data['capacitor']
         co2 = round(float(solar_data['co2_emission_reduction']) / 1000000, 5)
         solar_data['co2_emission_reduction'] = str(co2)
         solar_data['today_eq_Wh'] = solar_data['today_eq']

--- a/edge/jsons/plant.json
+++ b/edge/jsons/plant.json
@@ -1,13 +1,13 @@
 {
     "sensor": {
-        "capacitor": {
-            "name": "capacitor",
+        "array_size": {
+            "name": "array_size",
             "device_class": "power",
             "icon": "mdi:solar-panel",
             "unit_of_measurement": "W"
         },
-        "capacitor_kW": {
-            "name": "capacitor_kW",
+        "array_size_kW": {
+            "name": "array_size_kW",
             "device_class": "power",
             "icon": "mdi:solar-panel",
             "unit_of_measurement": "kW"

--- a/edge/jsons/sensor.json
+++ b/edge/jsons/sensor.json
@@ -1,12 +1,12 @@
 {
-   "capacitor":{
-      "name":"capacitor",
+   "array_size":{
+      "name":"array_size",
       "device_class":"power",
       "icon":"mdi:solar-panel",
       "unit_of_measurement":"W"
    },
-   "capacitor_kW":{
-      "name":"capacitor_kW",
+   "array_size_kW":{
+      "name":"array_size_kW",
       "device_class":"power",
       "icon":"mdi:solar-panel",
       "unit_of_measurement":"kW"


### PR DESCRIPTION
solar_data['capacitor'] is the size of the solar array in W. Rename to solar_data('array_size').

The dictionary that is retrieved from the S-Miles Cloud website has a key: 'capacitor', which is the size of the PV array in Watts.  Replace this key with 'array_size' and replace the key: 'capacitor_kW' with 'array_size_kW'.

Please note that this is the 1st pull request I have ever placed.  If I'm getting things wrong, guidance would be appreciated.